### PR TITLE
Update CFSSL to 1.4.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,15 @@
+on:
+  push:
+  create:
+  pull_request:
+
+jobs:
+  test-build-container:
+    name: Test Container Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Building Docker Image
+      env:
+        CONTAINER_IMAGE_NAME: gh_actions_test
+      run: docker build -t $CONTAINER_IMAGE_NAME:ci-test .

--- a/etc/csr_root_ca.json
+++ b/etc/csr_root_ca.json
@@ -1,8 +1,8 @@
 {
   "CN": "Astarte Root CA",
   "key": {
-    "algo": "ecdsa",
-    "size": 256
+    "algo": "rsa",
+    "size": 2048
   },
     "names": [
        {


### PR DESCRIPTION
This also brings some improvements to Dockerfile all around, and adds Github Actions for checking the container build.