### PR TITLE
cfssl: Allow (and default to) starting without a certdb

### DIFF
--- a/bin/start-cfssl.sh
+++ b/bin/start-cfssl.sh
@@ -7,34 +7,46 @@ cp /config/* /etc/cfssl/ || true
 
 # Generate keys if necessary
 if [ ! -f /etc/cfssl/ca.pem ] || [ ! -f /etc/cfssl/ca-key.pem ] ; then
-	# Do we have a persistent CA?
-	if [ ! -f /data/ca.pem ] || [ ! -f /data/ca-key.pem ] ; then
-	    # Create root
-	    cd /data
-	    cfssl gencert -initca "/etc/cfssl/csr_root_ca.json" | cfssljson -bare ca
-	    cd -
-	fi
+    # Do we have a persistent CA?
+    if [ ! -f /data/ca.pem ] || [ ! -f /data/ca-key.pem ] ; then
+        # Create root
+        cd /data
+        cfssl gencert -initca "/etc/cfssl/csr_root_ca.json" | cfssljson -bare ca
+        cd -
+    fi
 else
-	# Copy and override in case
-	cp /etc/cfssl/*.pem /data/
+    # Copy and override in case
+    cp /etc/cfssl/*.pem /data/
 fi
 
-# Migrate database
-db_driver=$(cat /etc/cfssl/db_config.json | jq -r ".driver")
-db_data_source=$(cat /etc/cfssl/db_config.json | jq -r ".data_source")
+# Check whether we want to use a Database or not
+if [[ -z "$CFSSL_USE_DB" ]]; then
+    echo "Will start CFSSL without a Database"
 
-rm /usr/local/share/cfssl/certdb/$db_driver/dbconf.yml
-cat > /usr/local/share/cfssl/certdb/$db_driver/dbconf.yml <<EOF
+    # Add config flags if cfssl
+    if [ "${1}" = 'cfssl' ]; then
+        set -- "$@" -config="/etc/cfssl/ca_root_config.json"
+    fi
+else
+    echo "Will configure a CertDB for CFSSL"
+
+    # Migrate database
+    db_driver=$(cat /etc/cfssl/db_config.json | jq -r ".driver")
+    db_data_source=$(cat /etc/cfssl/db_config.json | jq -r ".data_source")
+
+    rm /usr/local/share/cfssl/certdb/$db_driver/dbconf.yml
+    cat > /usr/local/share/cfssl/certdb/$db_driver/dbconf.yml <<EOF
 production:
   driver: $db_driver
   open: $db_data_source
 EOF
 
-goose -env production -path /usr/local/share/cfssl/certdb/$db_driver up
+    goose -env production -path /usr/local/share/cfssl/certdb/$db_driver up
 
-# Add config flags if cfssl
-if [ "${1}" = 'cfssl' ]; then
-	set -- "$@" -config="/etc/cfssl/ca_root_config.json" -db-config="/etc/cfssl/db_config.json"
+    # Add config flags if cfssl
+    if [ "${1}" = 'cfssl' ]; then
+        set -- "$@" -config="/etc/cfssl/ca_root_config.json" -db-config="/etc/cfssl/db_config.json"
+    fi
 fi
 
 exec "$@"

--- a/etc/db_config.json
+++ b/etc/db_config.json
@@ -1,4 +1,0 @@
-{
-  "driver": "sqlite3",
-  "data_source": "/data/cfssl.db"
-}


### PR DESCRIPTION
As a matter of fact, a certdb is not a requirement for standard operations. As such, allow starting cfssl without one.